### PR TITLE
Fix compatibility with newer React Native versions

### DIFF
--- a/src/spacer.js
+++ b/src/spacer.js
@@ -38,6 +38,14 @@ export default class Spacer extends React.PureComponent {
         Keyboard.removeListener(hideListenerEvent, this._keyboardWillHide);
     }
 
+    _getContainer() {
+      // calling getNode on the ref is no longer necessary in the future
+      // https://github.com/react-navigation/react-native-safe-area-view/issues/111
+      return this._container.measureInWindow
+          ? this._container
+          : this._container.getNode();
+    }
+
     _keyboardWillHide = () => {
         if (this.props.enabled && this._isActive) {
             this._isActive = false;
@@ -54,7 +62,7 @@ export default class Spacer extends React.PureComponent {
             // In some cases, this._container return null
             // This step make sure this._container is not null in order to use measureInWindow
             if (this._container) {
-                this._container._component.measureInWindow((x, y, w, h) => {
+                this._getContainer().measureInWindow((x, y, w, h) => {
                     // Calculation new position above the keyboard
                     let toValue = (y + h) - (windowHeight - (ev.endCoordinates.height + this._spaceMargin));
                     this._animate(-1 * toValue, this.props.animationDuration).start();
@@ -73,6 +81,7 @@ export default class Spacer extends React.PureComponent {
         return Animated.timing(this._topValue, {
             toValue,
             duration,
+            useNativeDriver: false
         });
     };
 
@@ -86,8 +95,7 @@ export default class Spacer extends React.PureComponent {
         if (y = ev.nativeEvent.layout.y) {
             this._locationY = y
         } else {
-            this._container
-                ._component
+            this._getContainer()
                 .measureInWindow((x, y, width, height) => {
                     this._locationY = y;
                 })


### PR DESCRIPTION
We recently updated our app from React Native version 0.60.4 to 0.62.2, and noticed that `react-native-spacer` is throwing an error. The reason for this is that the library is using a private property `_component`, which no longer seems to be available. 

When looking into why the error is thrown, I noticed that ` react-native-safe-area-view` library was previosly using the same private property, but has since then updated the code to use an alternative way to get the component.

I also fixed a warning that that React Native 0.62 is giving, which is that the `useNativeDriver` property needs to be explicitly set when animating with the `Animated` api. I set the value to `false` (default) since using `true` can in some cases be buggy.

I have tested the changes with React Native 0.60.4 and 0.62.2

@hieunc229 

Changes:

- Fix error thrown in newer React Native versions because of the usage of private _component
- Explicitly set useNativeDriver to false (warning in newer React Native versions)

The fix for the measureInWindow comes from `react-native-safe-area-view` repo:
- https://github.com/react-navigation/react-native-safe-area-view/pull/71
- https://github.com/react-navigation/react-native-safe-area-view/issues/111
- https://github.com/react-navigation/react-native-safe-area-view/commit/6661373a8e832c2af6db42ab08cc4dc319624bfe